### PR TITLE
Updates for Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'coveralls', require: false
+gem 'coveralls', '0.8.11', require: false
+gem 'term-ansicolor', '1.3.2'
 gem 'guard'
 gem 'guard-rspec'
 gem 'rake'
@@ -10,6 +11,8 @@ gem 'rubocop', '~> 0.34.0'
 gem 'simplecov'
 gem 'webmock', require: false
 gem 'yard'
+gem 'listen', '<= 3.0.6', require: false
+gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
 
 platforms :jruby do
   gem 'kramdown'


### PR DESCRIPTION
* Adds Gemfile versions for older rubies
* Fixes issue with older bundler on Travis 
* Allows continued testing of Ruby 2.0.0
* Allows continued testing of Ruby 1.9.3
* Allows continued testing of JRuby